### PR TITLE
Remove named release information from version.

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.10.0-cucwd-maple.1'  # pragma: no cover
+__version__ = '6.10.0'  # pragma: no cover


### PR DESCRIPTION
No need to keep named release information (e.g. `-cucwd-maple.1` in the python package version.