### PR TITLE
Expose organization location and sites fields in Django admin for Teak

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.13.0'  # pragma: no cover
+__version__ = '6.13.1'  # pragma: no cover

--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -66,6 +66,18 @@ class ActivateDeactivateAdminMixin:
 class OrganizationAdmin(ActivateDeactivateAdminMixin, admin.ModelAdmin):
     """ Admin for the Organization model. """
     actions = ['activate_selected', 'deactivate_selected']
+    fields = (
+        'name',
+        'short_name',
+        'description',
+        'logo',
+        'city',
+        'state',
+        'zipcode',
+        'sites',
+        'active',
+        'created',
+    )
     list_display = ('name', 'short_name', 'logo', 'active',)
     list_filter = ('active',)
     ordering = ('name', 'short_name',)

--- a/organizations/tests/test_admin.py
+++ b/organizations/tests/test_admin.py
@@ -40,10 +40,20 @@ class OrganizationsAdminTestCase(utils.OrganizationsTestCaseBase):
 
     def test_default_fields(self):
         """
-        Test: organization default fields should be name, description and active.
+        Test: organization admin should expose all editable organization fields.
         """
         self.assertEqual(list(self.org_admin.get_form(self.request).base_fields),
-                         ['name', 'short_name', 'description', 'logo', 'active'])
+                         [
+                             'name',
+                             'short_name',
+                             'description',
+                             'logo',
+                             'city',
+                             'state',
+                             'zipcode',
+                             'sites',
+                             'active',
+                         ])
 
     def test_organization_actions(self):
         """


### PR DESCRIPTION
Add city, state, zipcode, and sites to the Organization admin form. Update the admin regression test to verify that all organization fields remain available.
