### PR TITLE
Include Django admin assets in package for Teak

### DIFF
--- a/organizations/__init__.py
+++ b/organizations/__init__.py
@@ -1,4 +1,4 @@
 """
 edx-organizations app initialization module
 """
-__version__ = '6.14.2'  # pragma: no cover
+__version__ = '6.14.3'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
         'Programming Language :: Python :: 3.12',
     ],
     packages=find_packages(exclude=['tests']),
+    include_package_data=True,
     install_requires=load_requirements('requirements/base.in'),
 )


### PR DESCRIPTION
**Error**
```
django.template.exceptions.TemplateDoesNotExist: admin/grouped_choices_filter.html
```

**Solution**
Enable package data when building edx-organizations so the custom grouped-choice admin template and organization admin stylesheet are included in the installed wheel.

This prevents TemplateDoesNotExist errors when loading the organization changelist in deployed environments.

Bump the package version to 6.14.3.
